### PR TITLE
Add --wait flag for the write subcommand

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ nfpms:
   bindir: /usr/bin
   files:
     "_release/rtc.service": "/etc/systemd/system/rtc.service"
+    "_release/rtc-ntp.service": "/etc/systemd/system/rtc-ntp.service"
     "_release/sync-rtc.cron": "/etc/cron.hourly/sync-rtc"
   scripts:
     postinstall: "_release/postinstall.sh"

--- a/_release/postinstall.sh
+++ b/_release/postinstall.sh
@@ -2,3 +2,4 @@
 
 systemctl daemon-reload
 systemctl enable rtc
+systemctl enable rtc-ntp

--- a/_release/rtc-ntp.service
+++ b/_release/rtc-ntp.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Set the RTC on first NTP synchronisation
+After=multi-user.target network.target
+
+[Service]
+ExecStart=/usr/bin/rtc write --wait
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/alexflint/go-arg v1.2.0
+	github.com/rjeczalik/notify v0.9.2
 	periph.io/x/periph v3.6.2+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
+github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7 h1:bit1t3mgdR35yN0cX0G8orgLtOuyL9Wqxa1mccLB0ig=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 periph.io/x/periph v3.6.2+incompatible h1:B9vqhYVuhKtr6bXua8N9GeBEvD7yanczCvE0wU2LEqw=
 periph.io/x/periph v3.6.2+incompatible/go.mod h1:EWr+FCIU2dBWz5/wSWeiIUJTriYv9v2j2ENBmgYyy7Y=


### PR DESCRIPTION
This makes the rtc command block until NTP sync is acheived and then
up the RTC so that the RTC is corrected as soon as possible. The
regular cron job will take care of future syncs.